### PR TITLE
Make CYGWIN environment variable configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   packages:
     description: Packages to install, separated by a space
     required: false
+  env:
+    description: Value to set as the CYGWIN environment variable
+    required: false
 
 runs:
   using: composite
@@ -27,7 +30,7 @@ runs:
         New-Variable packages -Value '${{ inputs.packages}}' -Option Constant
 
         if ($windows_host) {
-            echo 'CYGWIN=winsymlinks:nativestrict' >> $env:GITHUB_ENV
+            echo 'CYGWIN=${{ inputs.env }}' >> $env:GITHUB_ENV
 
             $choco_params = @(
                 'install',


### PR DESCRIPTION
Some users might want different behaviour from the CYGWIN environment
variable, and in particular it seems reasonable to assume they don't
want non-default behaviour unless they explicitly ask for it.  As such,
make the environment variable configurable, and default to empty.

This change is not backwards compatible: prior to this change a Cygwin
install will have CYGWIN=winsymlinks:nativestrict, whereas afterwards
the variable will default to blank.  To obtain the previous behaviour, a
user would need to add `env: 'winsymlinks:nativestrict'` to the set of
inputs.

Fixes #1.